### PR TITLE
Fix strncpy off-by-one bug.

### DIFF
--- a/front/sdl/main.c
+++ b/front/sdl/main.c
@@ -358,7 +358,7 @@ static vxt_byte emu_control(enum vxtp_ctrl_command cmd, void *userdata) {
 static struct vxt_pirepheral *load_bios(const char *path, vxt_pointer base) {
 	size_t path_len = strcspn(path, "@");
 	char *file_path = (char*)SDL_malloc(path_len + 1);
-	strncpy(file_path, path, path_len);
+	strncpy(file_path, path, path_len + 1);
 	
 	int size = 0;
 	vxt_byte *data = vxtu_read_file(&realloc, file_path, &size);

--- a/front/sdl/virtualxt.docopt
+++ b/front/sdl/virtualxt.docopt
@@ -14,8 +14,8 @@ Options:
   --joystick              Enable joystick support.
   --rifs=PATH             Enable experimental RIFS support. (Shared folders)
   --config=PATH           Set config directory.
-  --bios=FILE             BIOS binary.
-  --extension=FILE        VirtualXT BIOS extension binary.
+  --bios=FILE[@addr]      BIOS binary.
+  --extension=FILE[@addr] VirtualXT BIOS extension binary.
   --trace=FILE            Write CPU trace to file.
   --vga=FILE              Load VGA BIOS.
   -f --frequency=MHZ      CPU frequency lock (0 to disable) [default: 4.77].


### PR DESCRIPTION
`path_len` is the length of path without the NUL terminator. Because `strncpy` writes only n characters, it would not include the NUL terminator in the `path` string in the write to `file_path`. This caused problems when SDL gave us a pointer to non-zeroed memory in `file_path`.

Change the call to `strncpy` to write `path_len` + 1, which is both the size of the `file_path` buffer and the size of `path` including the NUL terminator. Now `file_path` will be correct.

Are there any other considerations? I'm not clear on the reason for using `strcspn` instead of `strlen` in the `load_bios` function:

> 	size_t path_len = strcspn(path, "@");
