### PR TITLE
Enable compilation for more unix platforms

### DIFF
--- a/tools/package/libretro/Makefile
+++ b/tools/package/libretro/Makefile
@@ -47,7 +47,7 @@ ifeq ($(STATIC_LINKING), 1)
    EXT := a
 endif
 
-ifeq ($(platform), unix)
+ifneq (,$(findstring unix,$(platform)))
 	EXT ?= so
    TARGET := $(TARGET_NAME)_libretro.$(EXT)
    fpic := -fPIC


### PR DESCRIPTION
Compilation was not successful for "unix-armv7-hardfloat-neon" (one of the options in libretro-super build scripts).