### PR TITLE
update libretro makefile for newer emscripten sdk

### DIFF
--- a/tools/package/libretro/Makefile
+++ b/tools/package/libretro/Makefile
@@ -112,6 +112,8 @@ else ifeq ($(platform), emscripten)
    TARGET := $(TARGET_NAME)_libretro_emscripten.bc
    fpic := -fPIC
    SHARED := -shared -Wl,--no-undefined
+   STATIC_LINKING=1
+   AR = emar
 else
    TARGET := $(TARGET_NAME)_libretro.dll
    SHARED := -shared -static-libgcc -s -Wl,--no-undefined


### PR DESCRIPTION
Emscripten is a static linked platform and should use emar for archiving.