### PR TITLE
Define _POSIX_C_SOURCE to expose popen/pclose

### DIFF
--- a/front/sdl/main.c
+++ b/front/sdl/main.c
@@ -21,6 +21,11 @@
 //
 // 3. This notice may not be removed or altered from any source distribution.
 
+/* The Mac OS X libc API selection is broken (tested with Xcode 15.0.1) */
+#ifndef __APPLE__
+#define _POSIX_C_SOURCE 2 /* select POSIX.2-1992 to expose popen & pclose */
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>


### PR DESCRIPTION
# On musl libc
`popen`  and `pclose` aren't exposed  by musl libc unless one of the following macros is defined:
```C
#if defined(_POSIX_SOURCE) || defined(_POSIX_C_SOURCE) \
 || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
 || defined(_BSD_SOURCE)
```
# On Glibc
According to manpage `popen(3)` on Linux  man-pages `6.05.01` :
```
   Feature Test Macro Requirements for glibc (see feature_test_macros(7)):

       popen(), pclose():
           _POSIX_C_SOURCE >= 2
               || /* glibc <= 2.19: */ _BSD_SOURCE || _SVID_SOURCE
```
# Notes
* `_POSIX_SOURCE` has been superseded by  `_POSIX_C_SOURCE`.
* `_POSIX_C_SOURCE` with a value of 2 is the option that potentially causes  the least namespace contamination.

See [`feature_test_macros(7)`](https://www.man7.org/linux/man-pages/man7/feature_test_macros.7.html) for more  information  about the macros.